### PR TITLE
Making header parseable

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 layout: workshop
 root: .
 venue: University of St Andrews
-address:School of Physics and Astronomy, University of St Andrews, North Haugh, St Andrewws, KY16 9SS, Scotland
+address: School of Physics and Astronomy, University of St Andrews, North Haugh, St Andrewws, KY16 9SS, Scotland
 country: United-Kingdom
-language: English
+language: en
 latlng:  56.340085,-2.807146
-humandate: June 18-19, 2015
+humandate: Jun 18-19, 2015
 humantime: 9:30 am - 5:00 pm
 startdate: 2015-06-18 
 enddate: 2015-06-19


### PR DESCRIPTION
Unfortunately, there needs to be a space after the colon in the "key: value" pairs in the header.
